### PR TITLE
Fix for running Python files and OpenAI API key handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,8 +9,7 @@ from pptx.util import Inches
 import random 
 import re
 
-openai.api_key = "YOUR_API_KEY"
-client = openai.Client()
+client = openai.OpenAI(api_key='YOUR_API_KEY')
 
 app = Flask(__name__)
 
@@ -180,3 +179,7 @@ def get_bot_response():
 
     pptlink = create_ppt(f'Cache/{filename}.txt', number, filename)
     return str(pptlink)
+
+if __name__ == '__main__':
+    # debug=True in the run() parameter if you want to debug
+    app.run()


### PR DESCRIPTION
This pull request addresses two issues:
- Running Python files: Added the following code at the end of app.py to enable normal execution:
```python
if __name__ == '__main__':
    app.run()
```

- OpenAI API key: Updated the API key handling to:
```python
import openai
client = openai.OpenAI(api_key='api-key')
```
This removes the need to set the OPENAI_API_KEY environment variable in the terminal. 